### PR TITLE
Update mx.ui function name

### DIFF
--- a/src/ExitIntent/widget/ExitIntent.js
+++ b/src/ExitIntent/widget/ExitIntent.js
@@ -61,8 +61,9 @@ define([
             postCreate: function () {
                 // console.log(this)
                 logger.debug(this.id + ".postCreate");
-
-                this.handle = aspect.around(window.mx.ui, "openPage", dojoLang.hitch(this, this._aroundFunc));
+            
+                // Changed openPage to openForm2 -- This might be a error in mendix API, so if they fix this it has to be renamed back.
+                this.handle = aspect.around(window.mx.ui, "openForm2", dojoLang.hitch(this, this._aroundFunc));
                 this.handle2 = aspect.around(window.mx.ui.getContentForm(), "close", dojoLang.hitch(this, this._aroundFunc));
                 this._pageForm = this.mxform;
             },


### PR DESCRIPTION
openPage function seems to have been renamed to openForm2 after mendix version 7.16. 
Might be temporary fix. 
Verified on mx 7.22 to work.